### PR TITLE
Så man kan køre siden lokalt

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,7 @@ bld/
 
 # Visual Studio 2015 cache/options directory
 .vs/
+.vscode/
 # Uncomment if you have tasks that create the project's static files in wwwroot
 #wwwroot/
 

--- a/GamMaSite.csproj
+++ b/GamMaSite.csproj
@@ -24,6 +24,7 @@
     <PackageReference Include="Microsoft.AspNetCore.Routing" Version="2.2.2" />
     <PackageReference Include="Microsoft.AspNetCore.Routing.Abstractions" Version="2.2.0" />
     <PackageReference Include="Microsoft.AspNetCore.SpaServices.Extensions" Version="3.1.6" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="3.1.7" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="3.1.6" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="3.1.6" />
     <PackageReference Include="Microsoft.Extensions.Identity.Core" Version="3.1.6" />

--- a/Startup.cs
+++ b/Startup.cs
@@ -31,11 +31,16 @@ namespace GamMaSite
         // This method gets called by the runtime. Use this method to add services to the container.
         public void ConfigureServices(IServiceCollection services)
         {
-            services.AddDbContext<ApplicationDbContext>(options =>
-                options.UseMySql(
-                    Configuration.GetConnectionString("DefaultConnection")
-                    )
-                );
+            string DbConnectionString = Configuration.GetConnectionString("DefaultConnection");
+            if (DbConnectionString == "in-mem") {
+                services.AddDbContext<ApplicationDbContext>(options => options.UseInMemoryDatabase("DeveloperDB"));
+            } else {
+                services.AddDbContext<ApplicationDbContext>(options =>
+                    options.UseMySql(
+                        Configuration.GetConnectionString("DefaultConnection")
+                        )
+                    );
+            }
 
             services.AddDefaultIdentity<GamMaUser>(options => options.SignIn.RequireConfirmedAccount = true)
                 .AddEntityFrameworkStores<ApplicationDbContext>()

--- a/appsettings.Development.json
+++ b/appsettings.Development.json
@@ -1,4 +1,7 @@
 {
+  "ConnectionStrings": {
+    "DefaultConnection": "in-mem"
+  },
   "Logging": {
     "LogLevel": {
       "Default": "Information",


### PR DESCRIPTION
Tilføjer en tom database der kører i hukommelsen, så man kan udvikle på siden uden at have adgang til en stor CI/CD pipeline. Jeg aner ikke hvordan applikationen bruger databasen, så hvis den skal bootstrappes med relevant data er det nok nogle andre end mig der skal kigge på det :)

Og jeg er i øvrigt sikker på der er en bedre måde at gøre det på, det her var bare lige noget jeg faldt over i anden sammenhæng