### PR TITLE
Fix message recipient status filtering

### DIFF
--- a/Controllers/MessagesController.cs
+++ b/Controllers/MessagesController.cs
@@ -33,7 +33,18 @@ namespace GamMaSite.Controllers
 
         public async Task<IActionResult> Send(UserStatus[] status, string role, MessageMedia media, string subject, string messageBody, string smsBody)
         {
-            var usersToReceiveMessage = _userManager.Users.Where(user => status.Contains(user.Status)).ToHashSet();
+            var usersToReceiveMessage = new HashSet<SiteUser>();
+
+            if (status?.Length > 0)
+            {
+                var selectedStatuses = status.ToHashSet();
+                usersToReceiveMessage.UnionWith(
+                    _userManager.Users
+                        .AsEnumerable()
+                        .Where(user => selectedStatuses.Contains(user.Status))
+                );
+            }
+
             if (!String.IsNullOrEmpty(role))
             {
                 usersToReceiveMessage.UnionWith(await _userManager.GetUsersInRoleAsync(role));


### PR DESCRIPTION
Fix Messages/Send crash when filtering recipients by status

This PR fixes a server-side exception in the admin message flow that appeared when sending emails/SMS from /Messages/Send.

What was happening:

The app showed a generic ASP.NET error page in both test and production.
Mailgun was initially suspected, but local verification showed both the production and test Mailgun configurations were valid and could successfully queue messages.
Server logging on test revealed the real issue: the crash happened inside MessagesController.Send(...) while evaluating the LINQ status filter, before Mailgun was the actual problem.
Root cause:

The recipient query used status.Contains(user.Status) directly against _userManager.Users.
On the deployed environment, EF Core failed while trying to evaluate/translate that parameter expression, resulting in an unhandled exception.
Fix:

Made the recipient collection initialization null-safe.
Materialized the selected statuses into a HashSet.
Switched the status filtering to run in memory via AsEnumerable() before applying the Contains check.
Result:

The /Messages/Send flow now works again on test.
Mail sending succeeds without the server-side crash.