### PR TITLE
Fix global polyfill.io script causing login prompt on all pages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,3 +53,4 @@ multiproject.code-workspace
 .env
 .env.*
 *.log
+run-local.*

--- a/Views/Shared/_Layout.cshtml
+++ b/Views/Shared/_Layout.cshtml
@@ -27,7 +27,6 @@
     <link href="https://cdnjs.cloudflare.com/ajax/libs/summernote/0.8.20/summernote-lite.min.css" rel="stylesheet" integrity="sha512-ZbehZMIlGA8CTIOtdE+M81uj3mrcgyrh6ZFeG33A4FHECakGrOsTPlPQ8ijjLkxgImrdmSVUHn1j+ApjodYZow==" crossorigin="anonymous" referrerpolicy="no-referrer" />
     <script src="https://cdnjs.cloudflare.com/ajax/libs/summernote/0.8.20/summernote-lite.min.js" integrity="sha512-lVkQNgKabKsM1DA/qbhJRFQU8TuwkLF2vSN3iU/c7+iayKs08Y8GXqfFxxTZr1IcpMovXnf2N/ZZoMgmZep1YQ==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
     <!-- Stripe dependencies -->
-    <script src="https://polyfill.io/v3/polyfill.min.js?version=3.52.1&features=fetch"></script>
     <script src="https://js.stripe.com/v3/"></script>
     <!-- Custom CSS -->
     <link rel="stylesheet" href="~/css/site.css" />


### PR DESCRIPTION
Her er en kort PR-tekst, du kan bruge:

**Titel**  
`Fix global polyfill.io script causing login prompt on all pages`

**Beskrivelse**  
Denne PR fjerner den globale `polyfill.io`-reference fra shared layoutet, som udløste en uønsket login-prompt på alle sider på `gam-ma.dk`.

**Ændringer**  
- Fjernet `polyfill.io` fra `Views/Shared/_Layout.cshtml`
- Beholdt Stripe-scriptet intakt
- Fejlen rammer derfor ikke længere alle sider via fælles layout

**Verifikation**  
- `dotnet build` gennemført uden fejl
- Login-prompten skyldes ikke længere fælles script-indlæsning

